### PR TITLE
Compatibility with Epic Knights two-handed weapons, updating LootCategoryMixin.java

### DIFF
--- a/src/main/java/dev/muon/apothiccombat/mixin/LootCategoryMixin.java
+++ b/src/main/java/dev/muon/apothiccombat/mixin/LootCategoryMixin.java
@@ -15,7 +15,7 @@ public class LootCategoryMixin {
     @Inject(method = "forItem", at = @At("RETURN"), cancellable = true)
     private static void HeavyWeaponCategory(ItemStack itemStack, CallbackInfoReturnable<LootCategory> ci) {
         if (net.minecraftforge.fml.ModList.get().isLoaded("bettercombat")) {
-            if (ci.getReturnValue() == LootCategory.SWORD) {
+            if (ci.getReturnValue() == LootCategory.SWORD || ci.getReturnValue() == LootCategory.SHIELD) {
                 WeaponAttributes weaponAttributes = WeaponRegistry.getAttributes(itemStack);
                 if (weaponAttributes != null && weaponAttributes.isTwoHanded()) {
                     ci.setReturnValue(LootCategory.HEAVY_WEAPON);


### PR DESCRIPTION
Currently, two-handed weapons from the mod Epic Knights are treated as shields (I suppose this is because you can block with two-handed weapons); so they do not pass the check to verify they are swords. This leads to two-handed weapons from Epic Knights to never be converted to the heavy weapon category. This is a simple attempt to remedy this issue, testing it in game seems to have worked great. Actual shields are not converted to the heavy weapon category because they do not pass the check to verify that they are a two-handed weapon. If there are mods that have two-handed shields, this could cause issues since it would convert those shields to heavy weapons. Epic Knights has no such shields and neither does the base game.